### PR TITLE
Add 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import Footer from "@/components/Footer";
+
+export default function NotFound() {
+  return (
+    <>
+      <main className="relative bg-white/90 min-h-[80vh] flex items-center">
+        <div className="max-w-4xl mx-auto px-10 sm:px-16 py-24">
+          <div className="prose prose-lg">
+            <h1 className="mt-0">Page not found</h1>
+            <p>
+              The page you&apos;re looking for doesn&apos;t exist or may have
+              moved.
+            </p>
+            <Link href="/">Back to home</Link>
+          </div>
+        </div>
+      </main>
+      <div className="relative bg-white/90">
+        <Footer />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Add a 404 page for unmatched routes using Next.js App Router's `not-found.tsx` convention. The page matches the site design with consistent spacing, typography, and includes the footer. It displays a simple message with a back-to-home link.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>