### PR TITLE
Fix Huge Inc. logo aspect ratio and sizing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,8 +81,9 @@ export default async function Home() {
                 <ContinuousImage
                   src="/clients/huge-logo.png"
                   alt="Huge Inc. logo"
-                  width={120}
-                  height={40}
+                  width={316}
+                  height={316}
+                  className="h-32 w-auto"
                   radius={0.25}
                 />
               </div>


### PR DESCRIPTION
## Summary
Fixed the Huge Inc. logo display issue by updating intrinsic dimensions to match the actual 316×316px image file. Applied Tailwind's `h-32 w-auto` classes for proper sizing at 128px while maintaining aspect ratio.

## What changed
- Updated image `width` and `height` props to 316 (actual image dimensions)
- Added `className="h-32 w-auto"` for responsive, aspect-ratio-preserving display
- Resolves Next.js warning about CSS modifying one dimension without the other

## Test plan
- [ ] Verify logo displays at correct size and aspect ratio
- [ ] Check that no console warnings about image dimensions appear
- [ ] Test on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)