### PR TITLE
Increase article preview spacing at small breakpoint

### DIFF
--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -11,7 +11,7 @@ export default function ArticlePreview({
   hasContent?: boolean;
 }) {
   const inner = (
-    <div className="flex flex-col lg:flex-row gap-4 lg:gap-6">
+    <div className="flex flex-col lg:flex-row gap-4 sm:gap-8 lg:gap-6">
       <div className="relative w-full lg:flex-shrink-0 lg:w-[420px]" style={{ aspectRatio: "16/9" }}>
         <ContinuousImage
           src={


### PR DESCRIPTION
Adds sm:gap-8 to the article preview flex gap, increasing vertical space between image and text on screens above 640px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)