### PR TITLE
Update plans link text in fs-shows post

### DIFF
--- a/src/content/posts/fs-shows.md
+++ b/src/content/posts/fs-shows.md
@@ -11,4 +11,4 @@ Our band records every show we play and makes them available for streaming. I wa
 
 I built it as a library (and published it on npm) so it’s flexible, modular, and extensible. It uses backend adapters to work with your storage service of choice. It also works well on mobile, which is important for any music player.
 
-Plans for [improvements](https://github.com/nth-chile/fs-shows/issues).
+[See plans for improvements](https://github.com/nth-chile/fs-shows/issues).


### PR DESCRIPTION
## Summary
Changed the plans link in the fs-shows post from "Plans for [improvements]" to "[See plans for improvements]" so the entire phrase is the link text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)