### PR TITLE
Fix home page CTA visibility with divider styling

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -58,6 +58,7 @@ export default async function FAQPage() {
                 <CTASection
                     heading="Still have questions?"
                     description="I'd love to hear from you."
+                    card
                 />
             </main>
             <div className="relative bg-orange-50">

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -4,15 +4,31 @@ import { ReactNode } from "react"
 interface CTASectionProps {
     heading: string
     description: ReactNode
+    divider?: boolean
+    card?: boolean
 }
 
-export default function CTASection({ heading, description }: CTASectionProps) {
+export default function CTASection({ heading, description, divider = true, card = false }: CTASectionProps) {
+    if (card) {
+        return (
+            <section className="page-container py-12">
+                <div className="prose prose-xl bg-white shadow-lg rounded-2xl p-8 mx-auto text-center">
+                    <h2>{heading}</h2>
+                    <p>{description}</p>
+                    <ContactButton />
+                </div>
+            </section>
+        )
+    }
+
     return (
-        <section className="page-container py-12">
-            <div className="prose prose-xl bg-white shadow-lg rounded-2xl p-8 mx-auto text-center">
-                <h2>{heading}</h2>
-                <p>{description}</p>
-                <ContactButton />
+        <section className={`${divider ? "border-t border-gray-400 " : ""}py-12`}>
+            <div className="page-container">
+                <div className="prose prose-xl">
+                    <h2>{heading}</h2>
+                    <p>{description}</p>
+                    <ContactButton />
+                </div>
             </div>
         </section>
     )


### PR DESCRIPTION
## Summary

- Refactored CTASection to support two styling variants: divider-based (home page) and card-based (FAQ page)
- Fixed white-on-white text visibility on home page by replacing card background with a top border divider
- Left-aligned the home page CTA text to match resume section styling
- Preserved original card styling for FAQ page to maintain visual consistency