### PR TITLE
Improve project excerpts and marquee display

### DIFF
--- a/src/components/ProjectsMarquee.tsx
+++ b/src/components/ProjectsMarquee.tsx
@@ -43,7 +43,7 @@ export default function ProjectsMarquee({
               {frontMatter.title}
             </h2>
             {frontMatter.excerpt && (
-              <p className="text-white/90 text-sm line-clamp-3 drop-shadow-sm">
+              <p className="text-white/90 text-sm line-clamp-4 drop-shadow-sm">
                 {frontMatter.excerpt}
               </p>
             )}

--- a/src/content/posts/apple.md
+++ b/src/content/posts/apple.md
@@ -4,5 +4,5 @@ featuredImage: /posts/apple/apple.svg
 featuredImageWidth: 1600
 featuredImageHeight: 900
 imgClass: object-center
-excerpt: Built responsive marketing experiences for product launches, focusing on performance and accessibility.
+excerpt: Worked on apple.com/tv-pr — found performance bottlenecks, phased out legacy tooling, and collaborated with Apple's CMS team on API design. Also worked on an internal tool, delivering glassmorphism and WebGL shader effects.
 ---

--- a/src/content/posts/blackstone.md
+++ b/src/content/posts/blackstone.md
@@ -4,5 +4,5 @@ featuredImage: /posts/blackstone/blackstone.svg
 featuredImageWidth: 1600
 featuredImageHeight: 900
 imgClass: object-center
-excerpt: Created an animated banner ad generator and generated ad variants for high-impact Google Ads campaign.
+excerpt: Created an animated banner ad generator and produced ad variants for a high-impact Google Ads campaign.
 ---

--- a/src/content/posts/comcast.md
+++ b/src/content/posts/comcast.md
@@ -4,5 +4,5 @@ featuredImage: /posts/comcast/comcast.svg
 featuredImageWidth: 1600
 featuredImageHeight: 900
 imgClass: object-center
-excerpt: Evolved Peacock prototype through multiple development cycles guided by usability testing sessions. Built with React Native for tvOS.
+excerpt: Evolved Peacock prototypes in React Native for tvOS, guided by usability testing. Also built an in-store iPad experience deployed to 600+ Xfinity retail locations.
 ---

--- a/src/content/posts/openai.md
+++ b/src/content/posts/openai.md
@@ -4,5 +4,5 @@ featuredImage: /posts/openai/oai-logo.svg
 featuredImageWidth: 1604
 featuredImageHeight: 1006
 imgClass: object-center
-excerpt: Showcased novel generative AI by building interactive widgets and data visualizations to make complex concepts accessible through engaging, interactive experiences.
+excerpt: Built interactive widgets showcasing DALL-E and GPT-3, published alongside articles on openai.com.
 ---


### PR DESCRIPTION
## Summary
- Rewrote project excerpts with specific product/tech names and concrete outcomes instead of generic filler
- Increased marquee excerpt display from 3 to 4 lines for better readability
- Updated Blackstone, OpenAI, Apple, and Comcast excerpts with details from resume bullets

Each excerpt now reflects the actual impact (e.g., "600+ Xfinity retail locations", "DALL-E and GPT-3", "glassmorphism and WebGL shader effects").

🤖 Generated with [Claude Code](https://claude.com/claude-code)