### PR TITLE
Implement uniform article preview tiles with hover overlays

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,6 +115,7 @@ export default async function Home() {
               posts={getPostsBySlug([...EXPERIENCE_PROJECTS]).filter(
                 (post) => post !== undefined
               )}
+              gridOrder={['apple', 'comcast', 'openai', 'elephant-website', 'blackstone']}
             />
           </div>
           <div className="page-container mt-16 mb-12">
@@ -127,7 +128,7 @@ export default async function Home() {
               </p>
             </div>
           </div>
-          <div className="page-container space-y-16 my-8">
+          <div className="page-container grid grid-cols-1 lg:grid-cols-2 gap-8 my-8">
             {getPostsBySlug([...CLIENT_PROJECTS])
               .filter((post) => post !== undefined)
               .map((post, index) => (
@@ -145,7 +146,7 @@ export default async function Home() {
           <div className="prose prose-lg">
             <h1>Passion Projects</h1>
           </div>
-          <div className="space-y-16 my-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 my-8">
             {getPostsBySlug([...PASSION_PROJECTS])
               .filter((post) => post !== undefined)
               .map((post, index) => (

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -1,5 +1,6 @@
 import ContinuousImage from "@/components/ContinuousImage";
 import Link from "next/link";
+import "@/styles/home.css";
 
 export default function ArticlePreview({
   frontMatter,
@@ -10,36 +11,85 @@ export default function ArticlePreview({
   slug: string;
   hasContent?: boolean;
 }) {
-  const inner = (
-    <div className="flex flex-col lg:flex-row gap-4 sm:gap-8 lg:gap-6">
-      {frontMatter.featuredImage && (
-        <div className="relative w-full lg:flex-shrink-0 lg:w-[420px]" style={{ aspectRatio: "16/9" }}>
-          <ContinuousImage
-            src={frontMatter.featuredImage}
-            alt={frontMatter.title}
-            fill
-            sizes="(min-width: 1024px) 420px, (min-width: 640px) calc(100vw - 120px), calc(100vw - 40px)" // depends on lg:w-[420px] and page-container padding (60px/20px)
-            className="object-cover"
-            radius={0.15}
-            shadow
-            material3d
-          />
+  const overlay = (
+    <>
+      {/* Desktop hover overlay */}
+      <div
+        className="article-preview-blur absolute inset-0 z-20 backdrop-blur-0 transition-[backdrop-filter] duration-300 group-hover:backdrop-blur-[6px] pointer-events-none"
+        style={{
+          mask: "linear-gradient(to top, white 0%, white 30%, transparent 90%)",
+        }}
+      />
+      <div className="article-preview-overlay absolute inset-0 z-20 opacity-0 transition-opacity duration-300 group-hover:opacity-100 pointer-events-none">
+        <div
+          className="absolute inset-0"
+          style={{
+            background: "linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.3) 40%, transparent 70%)",
+          }}
+        />
+        {/* Content */}
+        <div className="absolute inset-0 flex flex-col justify-end p-5" style={{ textShadow: "0 1px 2px rgba(0,0,0,0.2)" }}>
+          <h3 className="text-white font-semibold text-lg mb-1" style={{ textShadow: "0 1px 3px rgba(0,0,0,0.3)" }}>
+            {frontMatter.title}
+          </h3>
+          {frontMatter.excerpt && (
+            <p className="text-white/85 text-sm line-clamp-3 mb-0 leading-relaxed">
+              {frontMatter.excerpt}
+            </p>
+          )}
+          {hasContent && (
+            <p className="text-white/85 text-sm mt-2 mb-0">
+              Read more <svg className="inline w-3 h-3 ml-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+            </p>
+          )}
         </div>
-      )}
-      <div className="prose prose-lg flex-1">
-        <h3 className="text-2xl font-semibold mt-0 group-hover:underline">{frontMatter.title}</h3>
-        <p>{frontMatter.excerpt}</p>
+      </div>
+    </>
+  );
+
+  const tile = (
+    <div className="article-preview group">
+      <div
+        className="relative w-full"
+        style={{ aspectRatio: "16 / 9" }}
+      >
+        <ContinuousImage
+          src={frontMatter.featuredImage}
+          alt={frontMatter.title}
+          fill
+          sizes="(min-width: 1024px) 540px, calc(100vw - 40px)"
+          className={`${frontMatter.imgClass || ""} object-cover`}
+          radius={0.15}
+          shadow
+          material3d
+        >
+          {overlay}
+        </ContinuousImage>
+      </div>
+      {/* Touch fallback: shown below image on no-hover devices */}
+      <div className="article-preview-below mt-3">
+        <h3 className="text-lg font-semibold m-0">{frontMatter.title}</h3>
+        {frontMatter.excerpt && (
+          <p className="text-sm text-gray-600 mt-1 mb-0 line-clamp-3">
+            {frontMatter.excerpt}
+          </p>
+        )}
+        {hasContent && (
+          <p className="text-sm text-gray-600 mt-2 mb-0">
+            Read more <svg className="inline w-3 h-3 ml-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+          </p>
+        )}
       </div>
     </div>
   );
 
   if (hasContent) {
     return (
-      <Link href={`/projects/${slug}`} className="block no-underline group">
-        {inner}
+      <Link href={`/projects/${slug}`} className="block no-underline text-inherit">
+        {tile}
       </Link>
     );
   }
 
-  return inner;
+  return tile;
 }

--- a/src/components/ProjectsMarquee.tsx
+++ b/src/components/ProjectsMarquee.tsx
@@ -1,5 +1,7 @@
 import ContinuousImage from "@/components/ContinuousImage";
+import ArticlePreview from "@/components/ArticlePreview";
 import "@/styles/marquee.css";
+import "@/styles/home.css";
 
 interface Post {
   frontMatter: any;
@@ -9,12 +11,14 @@ interface Post {
 
 export default function ProjectsMarquee({
   posts,
+  gridOrder,
   className = "",
 }: {
   className?: string;
   posts: Post[];
+  gridOrder?: string[];
 }) {
-  const items = posts.map((post, index) => {
+  const marqueeItems = posts.map((post, index) => {
     const { frontMatter, slug, hasContent } = post;
     const Wrapper = hasContent ? "a" : "div";
     const wrapperProps = hasContent ? { href: `/projects/${slug}` } : {};
@@ -30,7 +34,7 @@ export default function ProjectsMarquee({
           src={frontMatter.featuredImage}
           alt={frontMatter.title}
           fill
-          sizes="(min-width: 640px) 461px, 384px" // depends on sm:h-72 (288px) and h-60 (240px) * aspectRatio 1.6
+          sizes="(min-width: 640px) 461px, 384px"
           priority
           className={`${frontMatter.imgClass || ""} object-cover`}
           radius={0.15}
@@ -38,15 +42,34 @@ export default function ProjectsMarquee({
           material3d
         >
           {/* Hover Overlay */}
-          <div className="absolute inset-0 z-20 flex flex-col justify-end p-6 opacity-0 transition-opacity duration-300 group-hover:opacity-100 bg-gradient-to-t from-black/40 via-black/30 to-transparent pointer-events-none">
-            <h2 className="text-white font-semibold text-xl mb-2 drop-shadow-sm">
-              {frontMatter.title}
-            </h2>
-            {frontMatter.excerpt && (
-              <p className="text-white/90 text-sm line-clamp-4 drop-shadow-sm">
-                {frontMatter.excerpt}
-              </p>
-            )}
+          <div
+            className="absolute inset-0 z-20 backdrop-blur-0 transition-[backdrop-filter] duration-300 group-hover:backdrop-blur-[6px] pointer-events-none"
+            style={{
+              mask: "linear-gradient(to top, white 0%, white 30%, transparent 90%)",
+            }}
+          />
+          <div className="absolute inset-0 z-20 opacity-0 transition-opacity duration-300 group-hover:opacity-100 pointer-events-none">
+            <div
+              className="absolute inset-0"
+              style={{
+                background: "linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.3) 40%, transparent 70%)",
+              }}
+            />
+            <div className="absolute inset-0 flex flex-col justify-end p-5" style={{ textShadow: "0 1px 2px rgba(0,0,0,0.2)" }}>
+              <h2 className="text-white font-semibold text-lg mb-1" style={{ textShadow: "0 1px 3px rgba(0,0,0,0.3)" }}>
+                {frontMatter.title}
+              </h2>
+              {frontMatter.excerpt && (
+                <p className="text-white/85 text-sm line-clamp-3 leading-relaxed">
+                  {frontMatter.excerpt}
+                </p>
+              )}
+              {hasContent && (
+                <p className="text-white/85 text-sm mt-2 mb-0">
+                  Read more <svg className="inline w-3 h-3 ml-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                </p>
+              )}
+            </div>
           </div>
         </ContinuousImage>
       </Wrapper>
@@ -54,14 +77,32 @@ export default function ProjectsMarquee({
   });
 
   return (
-    <div
-      className={`marquee projects-marquee overflow-hidden flex gap-8 py-10 ${className}`}
-      style={{ "--marquee-gap": "2rem" } as React.CSSProperties}
-    >
-      <div className="shrink-0 flex gap-8 marquee-group">{items}</div>
-      <div aria-hidden className="shrink-0 flex gap-8 marquee-group">
-        {items}
+    <>
+      {/* Hover devices: scrolling marquee */}
+      <div
+        className={`marquee-hover marquee projects-marquee overflow-hidden flex gap-8 py-10 ${className}`}
+        style={{ "--marquee-gap": "2rem" } as React.CSSProperties}
+      >
+        <div className="shrink-0 flex gap-8 marquee-group">{marqueeItems}</div>
+        <div aria-hidden className="shrink-0 flex gap-8 marquee-group">
+          {marqueeItems}
+        </div>
       </div>
-    </div>
+
+      {/* Touch devices: static grid with text below */}
+      <div className="marquee-touch-grid page-container grid-cols-1 lg:grid-cols-2 gap-8 py-8">
+        {(gridOrder
+          ? gridOrder.map((slug) => posts.find((p) => p.slug === slug)).filter(Boolean) as Post[]
+          : posts
+        ).map((post, index) => (
+          <ArticlePreview
+            key={index}
+            frontMatter={post.frontMatter}
+            slug={post.slug}
+            hasContent={post.hasContent}
+          />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,3 +1,47 @@
+/* Article preview tiles: text below in 1-col, hover overlay in 2-col (lg+) */
+.article-preview {
+  .article-preview-overlay,
+  .article-preview-blur {
+    display: none;
+  }
+
+  .article-preview-below {
+    padding-top: 0.5rem;
+    padding-bottom: 1.5rem;
+
+    @media (width >= 768px) {
+      padding-top: 0.75rem;
+      padding-bottom: 2rem;
+    }
+  }
+
+  @media (width >= 1024px) and (hover: hover) {
+    .article-preview-overlay,
+    .article-preview-blur {
+      display: flex;
+    }
+
+    .article-preview-below {
+      display: none;
+    }
+  }
+}
+
+/* Marquee: show on hover devices, static grid on touch */
+.marquee-touch-grid {
+  display: none;
+}
+
+@media (hover: none) {
+  .marquee-hover {
+    display: none;
+  }
+
+  .marquee-touch-grid {
+    display: grid;
+  }
+}
+
 .project-grid {
   article {
     @media (hover: hover) {


### PR DESCRIPTION
## Summary
- Unified article preview component across all homepage sections (Experience, Client Work, Passion Projects)
- Added frosted glass hover overlays with backdrop blur and gradient scrim on hover devices
- Responsive text display: text below image on touch/small screens, overlay on hover at lg+
- Marquee for Experience section appears on hover devices only; static grid on touch
- Swapped Client Work and Passion Projects to 2-column grid layouts
- Improved touch accessibility with proper spacing between tiles

## Test plan
- [ ] Verify hover overlay appears on desktop/hover devices at lg breakpoint
- [ ] Verify text displays below image on mobile/touch devices
- [ ] Verify Experience section shows marquee on hover devices, grid on touch
- [ ] Verify correct grid ordering on Experience touch view
- [ ] Verify "Read more" links visible on linked tiles only

🤖 Generated with Claude Code