### PR TITLE
Add smooth marquee deceleration on hover

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRef, useEffect, useCallback } from "react";
+
+interface MarqueeProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  duration?: number;
+}
+
+export default function Marquee({
+  children,
+  className = "",
+  style,
+  duration = 20,
+}: MarqueeProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stateRef = useRef({
+    offset: 0,
+    currentSpeed: 1,
+    targetSpeed: 1,
+    rafId: 0,
+    lastTime: 0,
+  });
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const state = stateRef.current;
+    const groups = container.querySelectorAll<HTMLElement>(".marquee-group");
+    if (groups.length === 0) return;
+
+    const tick = (time: number) => {
+      if (!state.lastTime) state.lastTime = time;
+      const dt = time - state.lastTime;
+      state.lastTime = time;
+
+      // Exponential ease toward target speed (frame-rate independent)
+      const lerpFactor = 1 - Math.pow(0.8, dt / 16.667);
+      state.currentSpeed +=
+        (state.targetSpeed - state.currentSpeed) * lerpFactor;
+      if (Math.abs(state.currentSpeed - state.targetSpeed) < 0.001) {
+        state.currentSpeed = state.targetSpeed;
+      }
+
+      // Calculate movement
+      const groupWidth = groups[0].offsetWidth;
+      const gap = parseFloat(getComputedStyle(container).gap) || 0;
+      const totalWidth = groupWidth + gap;
+      const pxPerMs = totalWidth / (duration * 1000);
+
+      state.offset += pxPerMs * dt * state.currentSpeed;
+
+      if (totalWidth > 0 && state.offset >= totalWidth) {
+        state.offset -= totalWidth;
+      }
+
+      const tx = `translateX(${-state.offset}px)`;
+      groups.forEach((group) => {
+        group.style.transform = tx;
+      });
+
+      state.rafId = requestAnimationFrame(tick);
+    };
+
+    state.rafId = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(state.rafId);
+      state.lastTime = 0;
+    };
+  }, [duration]);
+
+  const setTarget = useCallback((speed: number) => {
+    if (window.matchMedia("(hover: hover)").matches) {
+      stateRef.current.targetSpeed = speed;
+    }
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={style}
+      onMouseEnter={() => setTarget(0)}
+      onMouseLeave={() => setTarget(1)}
+      onFocus={() => setTarget(0)}
+      onBlur={() => setTarget(1)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ProjectsMarquee.tsx
+++ b/src/components/ProjectsMarquee.tsx
@@ -1,5 +1,6 @@
 import ContinuousImage from "@/components/ContinuousImage";
 import ArticlePreview from "@/components/ArticlePreview";
+import Marquee from "@/components/Marquee";
 import "@/styles/marquee.css";
 import "@/styles/home.css";
 
@@ -79,15 +80,15 @@ export default function ProjectsMarquee({
   return (
     <>
       {/* Hover devices: scrolling marquee */}
-      <div
-        className={`marquee-hover marquee projects-marquee overflow-hidden flex gap-8 py-10 ${className}`}
+      <Marquee
+        className={`marquee-hover marquee projects-marquee flex gap-8 py-10 ${className}`}
         style={{ "--marquee-gap": "2rem" } as React.CSSProperties}
       >
         <div className="shrink-0 flex gap-8 marquee-group">{marqueeItems}</div>
         <div aria-hidden className="shrink-0 flex gap-8 marquee-group">
           {marqueeItems}
         </div>
-      </div>
+      </Marquee>
 
       {/* Touch devices: static grid with text below */}
       <div className="marquee-touch-grid page-container grid-cols-1 lg:grid-cols-2 gap-8 py-8">

--- a/src/components/TestimonialsMarquee.tsx
+++ b/src/components/TestimonialsMarquee.tsx
@@ -5,6 +5,7 @@
 // import Particles, { initParticlesEngine } from "@tsparticles/react";
 // import { loadEmittersPlugin } from "@tsparticles/plugin-emitters";
 // import { loadSlim } from "@tsparticles/slim";
+import Marquee from "@/components/Marquee";
 import "@/styles/marquee.css";
 
 // const emitterDefaults = {
@@ -108,7 +109,7 @@ export default function TestimonialsMarquee() {
         )
 
     return (
-        <div className='marquee overflow-hidden flex gap-4 py-4'>
+        <Marquee className='marquee flex gap-4 py-4'>
             <div className='shrink-0 flex gap-4 marquee-group'>{items}</div>
             <div aria-hidden className='shrink-0 flex gap-4 marquee-group'>{items}</div>
             {/* {init && <Particles
@@ -148,7 +149,7 @@ export default function TestimonialsMarquee() {
                 }}
             />
             } */}
-        </div>
+        </Marquee>
     );
 
 }

--- a/src/styles/marquee.css
+++ b/src/styles/marquee.css
@@ -1,26 +1,7 @@
 .marquee {
   --marquee-gap: 1rem;
-
-  &:hover,
-  &:focus {
-    .marquee-group {
-      @media (hover: hover) {
-        animation-play-state: paused;
-      }
-    }
-  }
-}
-
-.marquee-group {
-  animation: scroll 20s linear infinite;
-}
-
-@keyframes scroll {
-  0% {
-    transform: translateX(0);
-  }
-
-  100% {
-    transform: translateX(calc(-100% - var(--marquee-gap)));
-  }
+  overflow-x: clip;
+  overflow-y: visible;
+  padding-inline: 1.25rem;
+  margin-inline: -1.25rem;
 }


### PR DESCRIPTION
## Summary

Replace CSS animation with JS-driven scroll using requestAnimationFrame. When hovering, the marquee now smoothly eases to a stop (~0.2s) instead of stopping abruptly. New `Marquee` component handles animation state and speed interpolation, while CSS now manages overflow clipping and shadow padding.

## Test plan

- Hover over projects and testimonials marquees—verify smooth deceleration
- Check drop shadows render correctly without clipping in Safari
- Ensure marquees resume scrolling on mouse leave
- Test on hover-capable devices only

🤖 Generated with [Claude Code](https://claude.com/claude-code)