### PR TITLE
Add active state styling to navigation links

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,8 +1,21 @@
+"use client"
+
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 
 export default function NavLink({ href, children }: { href: string, children: React.ReactNode }) {
+  const pathname = usePathname()
+  const isActive = pathname === href
+
   return (
-    <Link href={href} className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-black hover:underline transition-colors no-underline">
+    <Link
+      href={href}
+      className={`inline-flex items-center text-sm transition-colors no-underline hover:underline ${
+        isActive
+          ? "font-semibold text-gray-700 hover:text-gray-700"
+          : "font-medium text-gray-600 hover:text-gray-700"
+      }`}
+    >
       {children}
     </Link>
   )


### PR DESCRIPTION
## Summary
Navigation links now display an active state to indicate which page the user is currently viewing. The active link is bold (font-semibold) and slightly darker (gray-700) compared to inactive links (gray-600).

Uses Next.js `usePathname()` to detect the current route and conditionally apply styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)