### PR TITLE
Make h2/h3 body-sized + bold, body text 90% opacity

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -95,7 +95,7 @@ export default async function Home() {
                   radius={0.25}
                 />
               </div>
-              <h2 className="!mb-2">Huge Inc. & Elephant</h2>
+              <h2 className="">Huge Inc. & Elephant</h2>
               <p>
                 I&apos;ve been fortunate to work with
                 sister companies{" "}
@@ -122,7 +122,7 @@ export default async function Home() {
           </div>
           <div className="page-container mt-16 mb-12">
             <div className="prose prose-lg">
-              <h2 className="!mb-2">Direct Client Work</h2>
+              <h2 className="">Direct Client Work</h2>
               <p>
                 Over the years, I&apos;ve worked with a range of companies and
                 organizations on projects spanning web development, design

--- a/src/components/ResumeContent.tsx
+++ b/src/components/ResumeContent.tsx
@@ -19,12 +19,12 @@ function renderWithLinks(text: string) {
 
 export default function ResumeContent({ resume }: Props) {
   return (
-    <div className="font-sans">
+    <div className="font-sans text-gray-950/90">
 
       {resume.experience.map((job) => (
         <div key={job.company} className="mt-8 first:mt-0">
           <div className="flex justify-between items-baseline gap-4 mb-1">
-            <h3 className="m-0 text-xl font-bold leading-tight">{job.company}</h3>
+            <h3 className="m-0 font-bold leading-tight">{job.company}</h3>
             <span className="text-sm font-bold tabular-nums shrink-0">{job.period}</span>
           </div>
           <p className="text-[14px] italic leading-snug mt-0.5 mb-1">{job.description}</p>
@@ -55,7 +55,7 @@ export default function ResumeContent({ resume }: Props) {
       ))}
 
       <div className="mt-8">
-        <h3 className="m-0 text-xl font-bold leading-tight mb-1">Other contract work</h3>
+        <h3 className="m-0 font-bold leading-tight mb-1">Other contract work</h3>
         <ul className="list-disc ml-5 text-[15px] leading-snug">
           {resume.otherWork.bullets.map((bullet, i) => (
             <li key={i}>{renderWithLinks(bullet)}</li>
@@ -65,7 +65,7 @@ export default function ResumeContent({ resume }: Props) {
 
       <div className="mt-8">
         <div className="flex justify-between items-baseline gap-4 mb-1">
-          <h3 className="m-0 text-xl font-bold leading-tight">Passion projects</h3>
+          <h3 className="m-0 font-bold leading-tight">Passion projects</h3>
           <span className="text-sm font-bold tabular-nums shrink-0">{resume.passionProjects.period}</span>
         </div>
         <ul className="list-disc ml-5 text-[15px] leading-snug">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,11 +5,30 @@ module.exports = {
             typography: {
                 DEFAULT: {
                     css: {
-                        color: 'var(--color-gray-950)',
+                        color: 'color-mix(in srgb, var(--color-gray-950) 90%, transparent)',
                         a: {
                             color: 'var(--color-gray-950)',
                             // '&:hover': { color: ... },
                         },
+                        h2: { fontSize: '1em', fontWeight: '700', marginTop: '1.5em', marginBottom: '0' },
+                        h3: { fontSize: '1em', fontWeight: '700', marginTop: '1.25em', marginBottom: '0' },
+                        h4: { fontSize: '1em', fontWeight: '700' },
+                        h5: { fontSize: '1em', fontWeight: '700' },
+                        h6: { fontSize: '1em', fontWeight: '700' },
+                    },
+                },
+                lg: {
+                    css: {
+                        h2: { fontSize: '1em', fontWeight: '700', marginTop: '1.5em', marginBottom: '0' },
+                        h3: { fontSize: '1em', fontWeight: '700', marginTop: '1.25em', marginBottom: '0' },
+                        h4: { fontSize: '1em', fontWeight: '700' },
+                    },
+                },
+                xl: {
+                    css: {
+                        h2: { fontSize: '1em', fontWeight: '700', marginTop: '1.5em', marginBottom: '0' },
+                        h3: { fontSize: '1em', fontWeight: '700', marginTop: '1.25em', marginBottom: '0' },
+                        h4: { fontSize: '1em', fontWeight: '700' },
                     },
                 },
             },


### PR DESCRIPTION
Make certain headings body-sized with just bold weight, and reduce body text opacity to 90%.

**Changes:**
- h2, h3, h4, h5, h6 in prose: set to body font-size (1em) with bold weight, zero margin-bottom for tight spacing
- Body/paragraph text: reduce opacity to 90% using color-mix
- Remove text-xl from ResumeContent h3 headings (company names, section titles)
- Remove !mb-2 overrides on h2s in page.tsx since headings now flow naturally

Matches Gage's design direction for cleaner, more editorial typography hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)