### PR TITLE
Replace large Huge Inc. logo with inline logos in intro

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,24 +85,14 @@ export default async function Home() {
           <div className="page-container">
             <div className="prose prose-lg">
               <h1>Experience</h1>
-              <div className="not-prose mt-16 -mb-10">
-                <ContinuousImage
-                  src="/clients/huge-logo.png"
-                  alt="Huge Inc. logo"
-                  width={316}
-                  height={316}
-                  className="h-32 w-auto"
-                  radius={0.25}
-                />
-              </div>
               <h2 className="!mb-2">Huge Inc. & Elephant</h2>
               <p>
                 I&apos;ve been fortunate to work with
-                sister companies{" "}
+                sister companies <L name="huge" />{" "}
                 <a href="https://www.hugeinc.com/" target="_blank">
                   Huge Inc.
                 </a>{" "}
-                &{" "}
+                & <L name="elephant" />{" "}
                 <a href="https://www.elephant.is/" target="_blank">
                   Elephant
                 </a>{" "}

--- a/src/components/InlineLogo.tsx
+++ b/src/components/InlineLogo.tsx
@@ -130,6 +130,12 @@ const logos: Record<string, ReactNode> = {
       </g>
     </svg>
   ),
+  huge: (
+    <img src="/clients/huge-logo.png" alt="Huge Inc." className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
+  ),
+  elephant: (
+    <img src="/clients/elephant.png" alt="Elephant" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
+  ),
   electron: (
     <svg viewBox="0 0 24 24" className="inline-block h-[1em] w-auto align-[-0.1em]">
       <path


### PR DESCRIPTION
## Summary
- Removed the large ContinuousImage logo block from the Experience section
- Added inline logo components for Huge Inc. and Elephant next to their text links
- Logos are styled to match other tech brand logos throughout the site

## Test plan
- [ ] Verify logos appear inline with the text
- [ ] Check that link underlines only apply to text, not logos
- [ ] Confirm responsive behavior at different screen sizes