### PR TITLE
Reduce line-height to 1.333 ratio for tighter spacing

### DIFF
--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -33,7 +33,7 @@ export default function ArticlePreview({
             {frontMatter.title}
           </h3>
           {frontMatter.excerpt && (
-            <p className="text-white/85 text-sm line-clamp-3 mb-0 leading-relaxed">
+            <p className="text-white/85 text-sm line-clamp-3 mb-0 leading-snug">
               {frontMatter.excerpt}
             </p>
           )}

--- a/src/components/ProjectsMarquee.tsx
+++ b/src/components/ProjectsMarquee.tsx
@@ -61,7 +61,7 @@ export default function ProjectsMarquee({
                 {frontMatter.title}
               </h2>
               {frontMatter.excerpt && (
-                <p className="text-white/85 text-sm line-clamp-3 leading-relaxed">
+                <p className="text-white/85 text-sm line-clamp-3 leading-snug">
                   {frontMatter.excerpt}
                 </p>
               )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,7 @@ body {
 
 body {
   overflow-x: hidden;
+  line-height: 1.333;
 }
 
 .page-container {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,11 +5,22 @@ module.exports = {
             typography: {
                 DEFAULT: {
                     css: {
+                        lineHeight: '1.333',
                         color: 'var(--color-gray-950)',
                         a: {
                             color: 'var(--color-gray-950)',
                             // '&:hover': { color: ... },
                         },
+                    },
+                },
+                lg: {
+                    css: {
+                        lineHeight: '1.333',
+                    },
+                },
+                xl: {
+                    css: {
+                        lineHeight: '1.333',
                     },
                 },
             },


### PR DESCRIPTION
## Summary
Applied consistent 1.333 line-height ratio across the site for tighter, more proportional text spacing. This means 24px line-height for 18px prose text, scaling proportionally for all other sizes.

## Changes
- Body copy and prose elements: 1.333 ratio applied via Tailwind typography config
- Card overlays: Changed from `leading-relaxed` (1.625) to `leading-snug` (1.375) for consistency
- Global baseline: Added 1.333 line-height to body element

## Test plan
- [ ] Review copy on homepage and background page for readability
- [ ] Check project card overlays in grid and marquee
- [ ] Verify testimonials section still reads well
- [ ] Test on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)