### PR TITLE
Round buttons and reduce corner radius

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ export default async function Home() {
                 width={190}
                 height={190}
                 placeholder="blur"
-                radius={0.25}
+                radius={0.12}
                 shadow
                 material3d
                 priority
@@ -73,7 +73,7 @@ export default async function Home() {
               <p>
                 <a
                   href="/background"
-                  className="inline-block no-underline font-medium text-sm tracking-[0.01em] py-2 px-4 bg-black text-white rounded-full hover:bg-gray-800 transition-colors duration-200"
+                  className="inline-block no-underline font-medium text-sm tracking-[0.01em] py-2 px-4 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors duration-200"
                 >
                   Read more
                 </a>
@@ -92,7 +92,7 @@ export default async function Home() {
                   width={316}
                   height={316}
                   className="h-32 w-auto"
-                  radius={0.25}
+                  radius={0.12}
                 />
               </div>
               <h2 className="!mb-2">Huge Inc. & Elephant</h2>
@@ -130,7 +130,7 @@ export default async function Home() {
               </p>
             </div>
           </div>
-          <div className="page-container grid grid-cols-1 lg:grid-cols-2 gap-8 my-8">
+          <div className="page-container grid grid-cols-1 lg:grid-cols-2 gap-5 my-8">
             {getPostsBySlug([...CLIENT_PROJECTS])
               .filter((post) => post !== undefined)
               .map((post, index) => (
@@ -148,7 +148,7 @@ export default async function Home() {
           <div className="prose prose-lg">
             <h1>Passion Projects</h1>
           </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 my-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 my-8">
             {getPostsBySlug([...PASSION_PROJECTS])
               .filter((post) => post !== undefined)
               .map((post, index) => (

--- a/src/app/projects/[projectSlug]/page.tsx
+++ b/src/app/projects/[projectSlug]/page.tsx
@@ -33,7 +33,7 @@ export default async function ProjectPage({ params }: any) {
   }
 
   return (
-    <main className='prose prose-img:rounded prose-img:shadow-lg'>
+    <main className='prose prose-img:rounded-lg prose-img:shadow-lg'>
       {frontMatter.featuredImageCaption && (
         <figure>
           <Image className="featured-image" src={frontMatter.featuredImage} alt="Project featured image" width={640} height={400} />

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -59,7 +59,7 @@ export default function ArticlePreview({
           fill
           sizes="(min-width: 1024px) 540px, calc(100vw - 40px)"
           className={`${frontMatter.imgClass || ""} object-cover`}
-          radius={0.15}
+          radius={0.06}
           shadow
           material3d
         >

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -12,7 +12,7 @@ export default function CTASection({ heading, description, divider = true, card 
     if (card) {
         return (
             <section className="page-container py-12">
-                <div className="prose prose-xl bg-white shadow-lg rounded-2xl p-8 mx-auto text-center">
+                <div className="prose prose-xl bg-white shadow-lg rounded-lg p-8 mx-auto text-center">
                     <h2>{heading}</h2>
                     <p>{description}</p>
                     <ContactButton />

--- a/src/components/ContactButton.tsx
+++ b/src/components/ContactButton.tsx
@@ -1,7 +1,7 @@
 export default function ContactButton() {
   return (
     <a
-      className="contact-button inline-block whitespace-nowrap no-underline font-medium text-sm tracking-[0.01em] py-2 px-4 bg-black text-white rounded-full hover:bg-gray-800 transition-colors duration-200"
+      className="contact-button inline-block whitespace-nowrap no-underline font-medium text-sm tracking-[0.01em] py-2 px-4 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors duration-200"
       target="_blank"
       href="mailto:jaredsalzano@gmail.com"
     >

--- a/src/components/ImgStack.tsx
+++ b/src/components/ImgStack.tsx
@@ -32,9 +32,9 @@ function Card({
       />
       <div className={`absolute top-[50%] -translate-y-[50%] z-20 transition-all duration-500 ease-[cubic-bezier(0.25,1,0.5,1)] ${getCardClasses(index)}`}>
         <label className="absolute inset-0" htmlFor={`card-${index}`} />
-        <div className={`p-1 bg-slate-100 rounded-lg ${isSelected ? "border shadow-2xl" : "shadow-lg"}`}>
+        <div className={`p-1 bg-slate-100 rounded-sm ${isSelected ? "border shadow-2xl" : "shadow-lg"}`}>
           <Image
-            className="rounded-lg"
+            className="rounded-sm"
             src={image.src}
             alt="test"
             width="600"

--- a/src/components/ProjectsMarquee.tsx
+++ b/src/components/ProjectsMarquee.tsx
@@ -38,7 +38,7 @@ export default function ProjectsMarquee({
           sizes="(min-width: 640px) 461px, 384px"
           priority
           className={`${frontMatter.imgClass || ""} object-cover`}
-          radius={0.15}
+          radius={0.06}
           shadow
           material3d
         >
@@ -81,17 +81,17 @@ export default function ProjectsMarquee({
     <>
       {/* Hover devices: scrolling marquee */}
       <Marquee
-        className={`marquee-hover marquee projects-marquee flex gap-8 py-10 ${className}`}
-        style={{ "--marquee-gap": "2rem" } as React.CSSProperties}
+        className={`marquee-hover marquee projects-marquee flex gap-5 py-8 ${className}`}
+        style={{ "--marquee-gap": "1.25rem" } as React.CSSProperties}
       >
-        <div className="shrink-0 flex gap-8 marquee-group">{marqueeItems}</div>
-        <div aria-hidden className="shrink-0 flex gap-8 marquee-group">
+        <div className="shrink-0 flex gap-5 marquee-group">{marqueeItems}</div>
+        <div aria-hidden className="shrink-0 flex gap-5 marquee-group">
           {marqueeItems}
         </div>
       </Marquee>
 
       {/* Touch devices: static grid with text below */}
-      <div className="marquee-touch-grid page-container grid-cols-1 lg:grid-cols-2 gap-8 py-8">
+      <div className="marquee-touch-grid page-container grid-cols-1 lg:grid-cols-2 gap-5 py-6">
         {(gridOrder
           ? gridOrder.map((slug) => posts.find((p) => p.slug === slug)).filter(Boolean) as Post[]
           : posts


### PR DESCRIPTION
## Summary
- Convert button corners from pill-shaped (`rounded-full`) to rounded rectangles (`rounded-lg`)
- Reduce border-radius on images: portrait/logo from `0.25` to `0.12`, article/project cards from `0.15` to `0.06`
- Update CTA card and prose images to `rounded-lg` for consistency
- Tighten spacing by reducing gaps from `gap-8` to `gap-5` and padding in marquee and grid layouts

Creates a more minimalist, angular aesthetic while maintaining visual consistency across components.

🤖 Generated with Claude