### PR TITLE
Convert testimonials from carousel to grid layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Footer from "@/components/Footer";
 
 import ArticlePreview from "@/components/ArticlePreview";
 import ProjectsMarquee from "@/components/ProjectsMarquee";
-import TestimonialsSlider from "@/components/TestimonialsSlider";
+import TestimonialsGrid from "@/components/TestimonialsGrid";
 import NavLink from "@/components/NavLink";
 import ContactButton from "@/components/ContactButton";
 import CTASection from "@/components/CTASection";
@@ -152,8 +152,8 @@ export default async function Home() {
           </div>
         </section>
 
-        <section className="bg-white py-8 lg:py-16 border-t border-b border-gray-400" aria-label="Testimonials">
-          <TestimonialsSlider />
+        <section className="bg-white py-12 lg:py-20 border-t border-b border-gray-400" aria-label="Testimonials">
+          <TestimonialsGrid />
         </section>
         <CTASection
           heading="Let's work together"

--- a/src/components/TestimonialsGrid.tsx
+++ b/src/components/TestimonialsGrid.tsx
@@ -1,0 +1,130 @@
+interface Testimonial {
+    id: number;
+    quote: string;
+    name: string;
+    secondLine?: string;
+    linkHref?: string;
+    linkText?: string;
+    logo?: string;
+    logoAlt?: string;
+    logoWide?: boolean;
+}
+
+const testimonials: Testimonial[] = [
+    {
+        id: 1234423,
+        quote: "Jared was a pleasure to work with at our shared time at Elephant. We worked alongside each other with a wide range of web technologies, including React and React Native. I could count on Jared to raise important UX, engineering and feasibility considerations. Any team would be lucky to have him.",
+        name: "Brittney Kernan",
+        secondLine: "Team Leader & Software Engineer at Notion",
+        logo: "/clients/notion.svg",
+        logoAlt: "Notion",
+    },
+    {
+        id: 4234,
+        quote: "Jared is one of the most creative and determined developers you will ever meet. He brings an all-world mindset to his programming, and is unflappable against challenges and roadblocks as they come up. He is an excellent choice for a development project.",
+        name: "Adam Spunberg",
+        secondLine: "Global Head of Operations, 100+ Accelerator, AB InBev",
+        logo: "/clients/abinbev.svg",
+        logoAlt: "AB InBev",
+        logoWide: true,
+    },
+    {
+        id: 1,
+        quote: "Jared was a smart choice to develop my personal portfolio. He accomplished all the things I was worried wouldn't work and was very patient with all my questions and feedback! He was very responsive and quick with updates. He even met with me in person to show me how to use the custom template he built in WordPress. The project met my vision and I am very happy with it. Thank you!",
+        name: "Denise M.",
+        secondLine: "Graphic design portfolio client",
+    },
+    {
+        id: 54325,
+        quote: "Jared was an outstanding software engineer on our team—technically sharp, collaborative, and always focused on delivering high-quality solutions. He consistently took initiative to solve complex problems and improve our product experience, often going above and beyond expectations. Any team would be lucky to have Jared's combination of technical excellence and strong communication skills.",
+        name: "David Skara",
+        secondLine: "Product Manager at Elephant",
+        logo: "/clients/elephant.png",
+        logoAlt: "Elephant",
+    },
+    {
+        id: 2,
+        quote: "Incredibly professional and nice guy to work with. Genuinely went above and beyond the product requirements.",
+        name: "Avi Muchnick",
+        secondLine: "Cofounder of Aviary (acquired by Adobe)",
+        logo: "/clients/adobe.svg",
+        logoAlt: "Adobe",
+    },
+    {
+        id: 3,
+        quote: "Jared was easy to get a hold of and plan out the project with. He was flexible as we had to change things around mid-project and stuck to timelines and budget.",
+        name: "Zach Holub",
+        secondLine: "Physical therapy website client",
+    },
+    {
+        id: 23,
+        quote: "Jared has been a great resource for our firm. He promptly executes on updates to our site and is a pleasure to work with.",
+        name: "Susie Baker",
+        linkHref: "https://spearstreetcapital.com/",
+        linkText: "spearstreetcapital.com",
+        logo: "/clients/spearstreet.svg",
+        logoAlt: "Spear Street Capital",
+    }
+];
+
+// Distribute items into columns so reading order is left-to-right, top-to-bottom
+// e.g. 7 items in 3 cols: col1=[0,3,6], col2=[1,4], col3=[2,5]
+function distributeIntoColumns<T>(items: T[], numCols: number): T[][] {
+    const cols: T[][] = Array.from({ length: numCols }, () => []);
+    items.forEach((item, i) => cols[i % numCols].push(item));
+    return cols;
+}
+
+function TestimonialCard({ linkHref, linkText, name, quote, secondLine, logo, logoAlt, logoWide }: Testimonial) {
+    return (
+        <article className="mb-8">
+            <blockquote className="font-serif italic text-xl text-gray-800 text-balance mb-4">
+                <p>{quote}</p>
+            </blockquote>
+            <cite className="not-italic">
+                <p className="font-bold text-base">{name}</p>
+                {secondLine && <span className="text-sm text-gray-600">{secondLine}</span>}
+                {linkHref && <a href={linkHref} target="_blank" className="text-sm text-nowrap hover:border-b border-b-gray-800">{linkText}
+                    <svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M2.31787 9.18188L7.97472 3.52503" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
+                        <path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
+                    </svg>
+                </a>}
+                {logo && <img src={logo} alt={logoAlt} className={`w-auto mt-2 grayscale opacity-40 ${logoWide ? 'h-5' : 'h-6'}`} />}
+            </cite>
+        </article>
+    );
+}
+
+const cols2 = distributeIntoColumns(testimonials, 2);
+const cols3 = distributeIntoColumns(testimonials, 3);
+
+export default function TestimonialsGrid() {
+    return (
+        <div className="px-6 sm:px-12 lg:px-20">
+            <p className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-gray-800 mb-10 lg:mb-14 text-balance max-w-4xl">
+                Don&apos;t take my word for it.
+            </p>
+            {/* Mobile: single column */}
+            <div className="sm:hidden">
+                {testimonials.map((t) => <TestimonialCard key={t.id} {...t} />)}
+            </div>
+            {/* Tablet: 2 columns */}
+            <div className="hidden sm:flex lg:hidden gap-8">
+                {cols2.map((col, i) => (
+                    <div key={i} className="flex-1">
+                        {col.map((t) => <TestimonialCard key={t.id} {...t} />)}
+                    </div>
+                ))}
+            </div>
+            {/* Desktop: 3 columns */}
+            <div className="hidden lg:flex gap-8">
+                {cols3.map((col, i) => (
+                    <div key={i} className="flex-1">
+                        {col.map((t) => <TestimonialCard key={t.id} {...t} />)}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Replace Swiper carousel with responsive 3-column grid that reads horizontally left-to-right. Add bold "Don't take my word for it." heading in Apple-style typography. Removes dependency on carousel library for cleaner implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)