### PR TITLE
Convert Direct Client Work and Passion Projects to carousels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2358,7 +2359,8 @@
         }
       ],
       "hasInstallScript": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tsparticles/interaction-external-attract": {
       "version": "3.7.1",
@@ -2854,6 +2856,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2926,6 +2929,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3176,6 +3180,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3651,6 +3656,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4150,7 +4156,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -4504,6 +4511,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4682,6 +4690,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7851,6 +7860,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -8526,6 +8536,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8535,6 +8546,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10291,7 +10303,8 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.4.tgz",
       "integrity": "sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -10388,6 +10401,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10588,6 +10602,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11114,6 +11129,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@ import getPreviewsForAllPosts from "@/utils/getPreviewsForAllPosts";
 import { EXPERIENCE_PROJECTS, CLIENT_PROJECTS, PASSION_PROJECTS } from "@/data/projects";
 import Footer from "@/components/Footer";
 
-import ArticlePreview from "@/components/ArticlePreview";
 import ProjectsMarquee from "@/components/ProjectsMarquee";
 import TestimonialsSlider from "@/components/TestimonialsSlider";
 import NavLink from "@/components/NavLink";
@@ -102,15 +101,13 @@ export default async function Home() {
               </p>
             </div>
           </div>
-          <div className="my-8">
-            <ProjectsMarquee
-              posts={getPostsBySlug([...EXPERIENCE_PROJECTS]).filter(
-                (post) => post !== undefined
-              )}
-              gridOrder={['apple', 'comcast', 'openai', 'elephant-website', 'blackstone']}
-            />
-          </div>
-          <div className="page-container mt-16 mb-12">
+          <ProjectsMarquee
+            posts={getPostsBySlug([...EXPERIENCE_PROJECTS]).filter(
+              (post) => post !== undefined
+            )}
+            gridOrder={['apple', 'comcast', 'openai', 'elephant-website', 'blackstone']}
+          />
+          <div className="page-container mt-4">
             <div className="prose prose-lg">
               <h2 className="">Direct Client Work</h2>
               <p>
@@ -120,36 +117,24 @@ export default async function Home() {
               </p>
             </div>
           </div>
-          <div className="page-container grid grid-cols-1 lg:grid-cols-2 gap-5 my-8">
-            {getPostsBySlug([...CLIENT_PROJECTS])
-              .filter((post) => post !== undefined)
-              .map((post, index) => (
-                <ArticlePreview
-                  key={index}
-                  frontMatter={post.frontMatter}
-                  slug={post.slug}
-                  hasContent={post.hasContent}
-                />
-              ))}
+          <ProjectsMarquee
+            posts={getPostsBySlug([...CLIENT_PROJECTS]).filter(
+              (post) => post !== undefined
+            )}
+            gridOrder={[...CLIENT_PROJECTS]}
+            duration={36}
+          />
+          <div className="page-container mt-4">
+            <div className="prose prose-lg">
+              <h2>Passion Projects</h2>
+            </div>
           </div>
-        </section>
-
-        <section className="page-container py-16" aria-label="Passion Projects">
-          <div className="prose prose-lg">
-            <h1>Passion Projects</h1>
-          </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 my-8">
-            {getPostsBySlug([...PASSION_PROJECTS])
-              .filter((post) => post !== undefined)
-              .map((post, index) => (
-                <ArticlePreview
-                  key={index}
-                  frontMatter={post.frontMatter}
-                  slug={post.slug}
-                  hasContent={post.hasContent}
-                />
-              ))}
-          </div>
+          <ProjectsMarquee
+            posts={getPostsBySlug([...PASSION_PROJECTS]).filter(
+              (post) => post !== undefined
+            )}
+            gridOrder={[...PASSION_PROJECTS]}
+          />
         </section>
 
         <section className="bg-white py-8 lg:py-16 border-t border-b border-gray-400" aria-label="Testimonials">

--- a/src/components/ProjectsMarquee.tsx
+++ b/src/components/ProjectsMarquee.tsx
@@ -14,10 +14,12 @@ export default function ProjectsMarquee({
   posts,
   gridOrder,
   className = "",
+  duration,
 }: {
   className?: string;
   posts: Post[];
   gridOrder?: string[];
+  duration?: number;
 }) {
   const marqueeItems = posts.map((post, index) => {
     const { frontMatter, slug, hasContent } = post;
@@ -83,6 +85,7 @@ export default function ProjectsMarquee({
       <Marquee
         className={`marquee-hover marquee projects-marquee flex gap-5 py-8 ${className}`}
         style={{ "--marquee-gap": "1.25rem" } as React.CSSProperties}
+        {...(duration ? { duration } : {})}
       >
         <div className="shrink-0 flex gap-5 marquee-group">{marqueeItems}</div>
         <div aria-hidden className="shrink-0 flex gap-5 marquee-group">


### PR DESCRIPTION
Replace static grids with ProjectsMarquee component for both sections, matching the Huge Inc. carousel experience. Added configurable duration prop to control scroll speed (36s for client work section with more items). Consistent vertical spacing between all three project sections. Touch device fallback uses static grid layout.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>