### PR TITLE
Add underline to active nav link

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -10,10 +10,10 @@ export default function NavLink({ href, children }: { href: string, children: Re
   return (
     <Link
       href={href}
-      className={`inline-flex items-center text-sm transition-colors no-underline hover:underline ${
+      className={`inline-flex items-center text-sm transition-colors hover:underline ${
         isActive
-          ? "font-semibold text-gray-700 hover:text-gray-700"
-          : "font-medium text-gray-600 hover:text-gray-700"
+          ? "font-semibold text-gray-700 hover:text-gray-700 underline"
+          : "font-medium text-gray-600 hover:text-gray-700 no-underline"
       }`}
     >
       {children}


### PR DESCRIPTION
The current page in the navigation now shows an underline to clearly indicate which page the user is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)