### PR TITLE
Shrink AB InBev logo to match other client logos

### DIFF
--- a/src/components/InlineLogo.tsx
+++ b/src/components/InlineLogo.tsx
@@ -147,7 +147,7 @@ const logos: Record<string, ReactNode> = {
     <img src="/clients/elephant.png" alt="Elephant" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
   ),
   abinbev: (
-    <img src="/clients/abinbev.svg" alt="AB InBev" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
+    <img src="/clients/abinbev.svg" alt="AB InBev" className="!inline-block !m-0 h-[0.8em] w-auto align-[-0.1em]" />
   ),
   spearstreet: (
     <img src="/clients/spearstreet.svg" alt="Spear Street Capital" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />


### PR DESCRIPTION
## Summary
Reduce the AB InBev logo height from 1em to 0.8em to achieve better visual balance with other client logos in the testimonials section.

## Changes
- Adjusted height from `h-[1em]` to `h-[0.8em]`
- Fine-tuned vertical alignment from `-0.15em` to `-0.1em`

🤖 Generated with [Claude Code](https://claude.com/claude-code)