### PR TITLE
Enhance testimonial citation links and styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,13 +76,13 @@ export default async function Home() {
           <div className="page-container">
             <div className="prose prose-lg">
               <h1>Experience</h1>
-              <h2 className="">Huge Inc. & Elephant</h2>
+              <h2 className="">Huge & Elephant</h2>
               <p>
                 I&apos;ve been fortunate to work with
                 sister companies{" "}
-                <span className="logo-group"><a href="https://www.hugeinc.com/" target="_blank" className="logo-link" aria-label="Huge Inc."><L name="huge" /></a>{" "}<a href="https://www.hugeinc.com/" target="_blank" className="logo-text">Huge Inc.</a></span>{" "}
+                <span className="logo-group"><a href="https://www.hugeinc.com/" target="_blank" className="logo-link" aria-label="Huge"><L name="huge" /></a>{" "}<a href="https://www.hugeinc.com/" target="_blank" className="logo-text">Huge<svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.31787 9.18188L7.97472 3.52503" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /><path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /></svg></a></span>{" "}
                 &{" "}
-                <span className="logo-group"><a href="https://www.elephant.is/" target="_blank" className="logo-link" aria-label="Elephant"><L name="elephant" /></a>{" "}<a href="https://www.elephant.is/" target="_blank" className="logo-text">Elephant</a></span>{" "}
+                <span className="logo-group"><a href="https://www.elephant.is/" target="_blank" className="logo-link" aria-label="Elephant"><L name="elephant" /></a>{" "}<a href="https://www.elephant.is/" target="_blank" className="logo-text">Elephant<svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.31787 9.18188L7.97472 3.52503" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /><path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /></svg></a></span>{" "}
                 on a variety of contract projects. Each engagement has brought new
                 challenges, creative problem-solving, and the opportunity to
                 collaborate with talented designers, developers, and strategists.

--- a/src/components/InlineLogo.tsx
+++ b/src/components/InlineLogo.tsx
@@ -141,13 +141,13 @@ const logos: Record<string, ReactNode> = {
     </svg>
   ),
   huge: (
-    <img src="/clients/huge-logo.png" alt="Huge Inc." className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
+    <img src="/clients/huge-logo.png" alt="Huge" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
   ),
   elephant: (
     <img src="/clients/elephant.png" alt="Elephant" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
   ),
   abinbev: (
-    <img src="/clients/abinbev.svg" alt="AB InBev" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
+    <img src="/clients/abinbev.svg" alt="AB InBev" className="!inline-block !m-0 h-[0.75em] w-auto align-middle" />
   ),
   spearstreet: (
     <img src="/clients/spearstreet.svg" alt="Spear Street Capital" className="!inline-block !m-0 h-[1em] w-auto align-[-0.15em]" />
@@ -161,7 +161,7 @@ const logos: Record<string, ReactNode> = {
     </svg>
   ),
   adobe: (
-    <svg viewBox="0 0 24 24" className="inline-block h-[1em] w-auto align-[-0.1em]">
+    <svg viewBox="0 0 24 24" className="inline-block h-[1em] w-auto align-[-0.15em]">
       <path
         fill="#FA0F00"
         d="m13.966 22.624l-1.69-4.281H8.122l3.892-9.144l5.662 13.425zM8.884 1.376H0v21.248zm15.116 0h-8.884L24 22.624Z"

--- a/src/components/TestimonialsGrid.tsx
+++ b/src/components/TestimonialsGrid.tsx
@@ -27,9 +27,7 @@ const testimonials: Testimonial[] = [
         id: 23,
         quote: "Jared has been a great resource for our firm. He promptly executes on updates to our site and is a pleasure to work with.",
         name: "Susie Baker",
-        secondLine: <><span className="logo-link"><L name="spearstreet" /></span></>,
-        linkHref: "https://spearstreetcapital.com/",
-        linkText: "spearstreetcapital.com",
+        secondLine: <>Chief Operating Officer at <a href="https://spearstreetcapital.com/" target="_blank" className="logo-link"><L name="spearstreet" /><svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.31787 9.18188L7.97472 3.52503" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /><path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /></svg></a></>,
     },
     {
         id: 4234,
@@ -65,7 +63,7 @@ function TestimonialCard({ linkHref, linkText, name, quote, secondLine }: Testim
             </blockquote>
             <cite className="not-italic">
                 <p className="font-bold text-base">{name}</p>
-                {secondLine && <span className="text-sm text-gray-600 [&_.logo-link]:text-lg">{secondLine}</span>}
+                {secondLine && <span className="text-sm text-gray-600 [&_.logo-link]:text-2xl [&_.logo-link>svg]:!align-middle [&_.logo-link>img]:!align-middle">{secondLine}</span>}
                 {linkHref && <a href={linkHref} target="_blank" className="text-sm text-nowrap hover:border-b border-b-gray-800">{linkText}
                     <svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M2.31787 9.18188L7.97472 3.52503" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />


### PR DESCRIPTION
## Summary
- Added external link arrows to Susie's Spear Street Capital link and experience section company links
- Scaled up testimonial citation logos to text-2xl with proper vertical alignment fixes
- Adjusted logo sizing for optical balance (AB InBev smaller, Adobe alignment improved)
- Renamed "Huge Inc." to "Huge" for consistency across the site

## Test plan
- View testimonials section to verify Susie's citation displays properly with logo and arrow
- Check experience section to confirm Huge and Elephant links have external arrows
- Verify logo alignment in testimonials (Adobe should be centered)
- Confirm AB InBev logo is appropriately scaled

🤖 Generated with [Claude Code](https://claude.com/claude-code)