### PR TITLE
Replace marquee with scroll-snap carousel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import getPreviewsForAllPosts from "@/utils/getPreviewsForAllPosts";
 import { EXPERIENCE_PROJECTS, CLIENT_PROJECTS, PASSION_PROJECTS } from "@/data/projects";
 import Footer from "@/components/Footer";
 
-import ProjectsMarquee from "@/components/ProjectsMarquee";
+import ProjectsCarousel from "@/components/ProjectsCarousel";
 import TestimonialsGrid from "@/components/TestimonialsGrid";
 import NavLink from "@/components/NavLink";
 import ContactButton from "@/components/ContactButton";
@@ -89,11 +89,10 @@ export default async function Home() {
               </p>
             </div>
           </div>
-          <ProjectsMarquee
+          <ProjectsCarousel
             posts={getPostsBySlug([...EXPERIENCE_PROJECTS]).filter(
               (post) => post !== undefined
             )}
-            gridOrder={['apple', 'comcast', 'openai', 'elephant-website', 'blackstone']}
           />
           <div className="page-container mt-4">
             <div className="prose prose-lg">
@@ -105,23 +104,20 @@ export default async function Home() {
               </p>
             </div>
           </div>
-          <ProjectsMarquee
+          <ProjectsCarousel
             posts={getPostsBySlug([...CLIENT_PROJECTS]).filter(
               (post) => post !== undefined
             )}
-            gridOrder={[...CLIENT_PROJECTS]}
-            duration={36}
           />
           <div className="page-container mt-4">
             <div className="prose prose-lg">
               <h2>Passion Projects</h2>
             </div>
           </div>
-          <ProjectsMarquee
+          <ProjectsCarousel
             posts={getPostsBySlug([...PASSION_PROJECTS]).filter(
               (post) => post !== undefined
             )}
-            gridOrder={[...PASSION_PROJECTS]}
           />
         </section>
 

--- a/src/components/ProjectsCarousel.tsx
+++ b/src/components/ProjectsCarousel.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useRef, useState, useCallback, useEffect } from "react";
+import ContinuousImage from "@/components/ContinuousImage";
+import "@/styles/carousel.css";
+
+interface Post {
+  frontMatter: any;
+  slug: string;
+  hasContent?: boolean;
+}
+
+function ArrowLeft() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ArrowRight() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+export default function ProjectsCarousel({
+  posts,
+  className = "",
+}: {
+  posts: Post[];
+  className?: string;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 2);
+    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 2);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    const ro = new ResizeObserver(updateScrollState);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      ro.disconnect();
+    };
+  }, [updateScrollState]);
+
+  // Close expanded card when tapping outside or scrolling
+  useEffect(() => {
+    if (expandedIndex === null) return;
+    const el = scrollRef.current;
+    const close = () => setExpandedIndex(null);
+    el?.addEventListener("scroll", close, { passive: true });
+    return () => el?.removeEventListener("scroll", close);
+  }, [expandedIndex]);
+
+  const scroll = useCallback((direction: 1 | -1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const amount = el.clientWidth * 0.8;
+    el.scrollBy({ left: direction * amount, behavior: "smooth" });
+  }, []);
+
+  const handleTouchTap = useCallback((e: React.MouseEvent, index: number, hasContent?: boolean) => {
+    // Only intercept on touch devices
+    if (window.matchMedia("(hover: hover)").matches) return;
+
+    if (expandedIndex === index) {
+      // Already expanded — let the link navigate (if it's a link)
+      return;
+    }
+
+    // First tap: expand the overlay, don't navigate
+    e.preventDefault();
+    setExpandedIndex(index);
+  }, [expandedIndex]);
+
+  return (
+    <div className={`carousel-wrapper ${className}`}>
+      {/* Left fade + arrow */}
+      <div
+        className={`carousel-edge carousel-edge-left ${canScrollLeft ? "carousel-edge-visible" : ""}`}
+      >
+        <button
+          className="carousel-arrow"
+          onClick={() => scroll(-1)}
+          aria-label="Scroll left"
+          tabIndex={canScrollLeft ? 0 : -1}
+        >
+          <ArrowLeft />
+        </button>
+      </div>
+
+      {/* Scrollable track */}
+      <div ref={scrollRef} className="carousel-track">
+        {posts.map((post, index) => {
+          const { frontMatter, slug, hasContent } = post;
+          const Wrapper = hasContent ? "a" : "div";
+          const wrapperProps = hasContent
+            ? { href: `/projects/${slug}` }
+            : {};
+          const isExpanded = expandedIndex === index;
+
+          return (
+            <Wrapper
+              key={slug || index}
+              {...wrapperProps}
+              className={`carousel-item group ${isExpanded ? "carousel-item-expanded" : ""}`}
+              onClick={(e: React.MouseEvent) => handleTouchTap(e, index, hasContent)}
+            >
+              <div className="carousel-item-image">
+                <ContinuousImage
+                  src={frontMatter.featuredImage}
+                  alt={frontMatter.title}
+                  fill
+                  sizes="(min-width: 640px) 461px, 384px"
+                  priority
+                  className={`${frontMatter.imgClass || ""} object-cover`}
+                  radius={0.06}
+                  shadow
+                  material3d
+                >
+                  {/* Always-visible title (touch) / hover overlay (desktop) */}
+                  <div
+                    className="carousel-overlay-blur absolute inset-0 z-20 pointer-events-none transition-[backdrop-filter] duration-300"
+                    style={{
+                      mask: "linear-gradient(to top, white 0%, white 30%, transparent 90%)",
+                    }}
+                  />
+                  {/* Gradient + text overlay */}
+                  <div
+                    className="carousel-overlay-info absolute inset-0 z-30 pointer-events-none transition-opacity duration-300"
+                    style={{ transform: "translateZ(0)" }}
+                  >
+                    <div
+                      className="absolute inset-0"
+                      style={{
+                        background:
+                          "linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.3) 40%, transparent 70%)",
+                      }}
+                    />
+                    <div
+                      className="absolute inset-0 flex flex-col justify-end p-5"
+                      style={{ textShadow: "0 1px 2px rgba(0,0,0,0.2)" }}
+                    >
+                      <h2
+                        className="text-white font-semibold text-lg mb-1"
+                        style={{
+                          textShadow: "0 1px 3px rgba(0,0,0,0.3)",
+                        }}
+                      >
+                        {frontMatter.title}
+                      </h2>
+                      {/* Excerpt + Read more: visible on hover (desktop) or when expanded (touch) */}
+                      <div className="carousel-overlay-details">
+                        {frontMatter.excerpt && (
+                          <p className="text-white/85 text-sm line-clamp-3 leading-snug">
+                            {frontMatter.excerpt}
+                          </p>
+                        )}
+                        {hasContent && (
+                          <p className="text-white/85 text-sm mt-2 mb-0">
+                            Read more{" "}
+                            <svg
+                              className="inline w-3 h-3 ml-0.5"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            >
+                              <path d="M5 12h14" />
+                              <path d="m12 5 7 7-7 7" />
+                            </svg>
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </ContinuousImage>
+              </div>
+            </Wrapper>
+          );
+        })}
+      </div>
+
+      {/* Right fade + arrow */}
+      <div
+        className={`carousel-edge carousel-edge-right ${canScrollRight ? "carousel-edge-visible" : ""}`}
+      >
+        <button
+          className="carousel-arrow"
+          onClick={() => scroll(1)}
+          aria-label="Scroll right"
+          tabIndex={canScrollRight ? 0 : -1}
+        >
+          <ArrowRight />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -1,0 +1,190 @@
+.carousel-wrapper {
+  position: relative;
+
+  /*
+   * Netflix-style proportional sizing: everything is vw-based so
+   * cards, gaps, padding, and peek all scale together fluidly.
+   *
+   * Card width ≈ 100vw / visible-count.
+   * The "peek" is implicit — it's just the leftover space after
+   * N full cards + gaps + padding.
+   */
+  --carousel-padding: 8vw;
+  --carousel-gap: 3vw;
+  --carousel-cards: 1.15; /* mobile: 1 card + peek */
+
+  @media (width >= 640px) {
+    --carousel-padding: 5vw;
+    --carousel-gap: 1vw;
+    --carousel-cards: 2.15; /* tablet: 2 cards + peek */
+  }
+
+  @media (width >= 1024px) {
+    --carousel-cards: 3.15; /* desktop: 3 cards + peek */
+  }
+}
+
+/* Scrollable track */
+.carousel-track {
+  display: flex;
+  gap: var(--carousel-gap);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-padding-left: var(--carousel-padding);
+  padding: 2rem var(--carousel-padding);
+
+  /* Hide scrollbar */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+/* Individual item */
+.carousel-item {
+  flex-shrink: 0;
+  scroll-snap-align: start;
+  cursor: default;
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.carousel-item-image {
+  position: relative;
+  aspect-ratio: 1.6 / 1;
+
+  /*
+   * Fully proportional card width:
+   * Available space = 100vw - 2*padding
+   * Total gap space = gap * (floor(cards) gaps, roughly cards-1 visible gaps)
+   * Card width = available / cards (cards is fractional, e.g. 3.15)
+   *
+   * This makes every pixel of viewport change scale the cards proportionally.
+   */
+  width: calc(
+    (100vw - 2 * var(--carousel-padding) - (var(--carousel-cards) - 1) * var(--carousel-gap))
+    / var(--carousel-cards)
+  );
+}
+
+/*
+ * Overlay behavior:
+ * - Desktop (hover: hover): hidden by default, full overlay on hover
+ * - Touch (hover: none): gradient+title always visible, excerpt on tap
+ */
+
+/* Desktop: overlay hidden until hover */
+@media (hover: hover) {
+  .carousel-overlay-blur {
+    backdrop-filter: blur(0.5px);
+  }
+
+  .carousel-overlay-info {
+    opacity: 0;
+  }
+
+  .carousel-item:hover .carousel-overlay-blur {
+    backdrop-filter: blur(6px);
+  }
+
+  .carousel-item:hover .carousel-overlay-info {
+    opacity: 1;
+  }
+}
+
+/* Touch: gradient+title always visible, details hidden until expanded */
+@media (hover: none) {
+  .carousel-overlay-blur {
+    backdrop-filter: blur(0px);
+  }
+
+  .carousel-overlay-info {
+    opacity: 1;
+  }
+
+  .carousel-overlay-details {
+    display: grid;
+    grid-template-rows: 0fr;
+    opacity: 0;
+    transition: grid-template-rows 300ms ease, opacity 300ms ease;
+    overflow: hidden;
+  }
+
+  .carousel-overlay-details > * {
+    min-height: 0;
+  }
+
+  .carousel-item-expanded .carousel-overlay-blur {
+    backdrop-filter: blur(6px);
+  }
+
+  .carousel-item-expanded .carousel-overlay-details {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+}
+
+/* Edge overlays (fade gradient + arrow button) */
+.carousel-edge {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 4rem;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.carousel-edge-left {
+  left: 0;
+  justify-content: flex-start;
+  padding-left: 0.5rem;
+  background: linear-gradient(to right, rgba(255,255,255,0.9) 0%, transparent 100%);
+}
+
+.carousel-edge-right {
+  right: 0;
+  justify-content: flex-end;
+  padding-right: 0.5rem;
+  background: linear-gradient(to left, rgba(255,255,255,0.9) 0%, transparent 100%);
+}
+
+.carousel-edge-visible {
+  /* Arrows visible on wrapper hover for hover-capable devices */
+  @media (hover: hover) {
+    .carousel-wrapper:hover & {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+}
+
+/* Arrow buttons */
+.carousel-arrow {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: white;
+  border: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 100ms ease, box-shadow 100ms ease;
+  color: #333;
+
+  &:hover {
+    transform: scale(1.08);
+    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -27,20 +27,6 @@
   }
 }
 
-/* Marquee: show on hover devices, static grid on touch */
-.marquee-touch-grid {
-  display: none;
-}
-
-@media (hover: none) {
-  .marquee-hover {
-    display: none;
-  }
-
-  .marquee-touch-grid {
-    display: grid;
-  }
-}
 
 .project-grid {
   article {


### PR DESCRIPTION
## Summary

Replaced the marquee component with a scroll-snap carousel featuring Netflix-style proportional sizing. Cards now scale fluidly with viewport width—showing 1/2/3 cards on mobile/tablet/desktop with a consistent peek ratio.

On touch devices, cards expand on tap to reveal the excerpt and "Read more" link. Desktop users see a smooth hover overlay with blur effect. All layout metrics (padding, gap, card width) are viewport-relative, creating visual consistency across all screen sizes.

Removed dead marquee CSS rules and simplified component props.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>