### PR TITLE
Remove external link arrows from testimonial citations

### DIFF
--- a/src/components/TestimonialsGrid.tsx
+++ b/src/components/TestimonialsGrid.tsx
@@ -15,12 +15,7 @@ function TestimonialCard({ linkHref, linkText, name, shorterQuote, secondLine }:
             <cite className="not-italic">
                 <p className="font-bold text-base">{name}</p>
                 {secondLine && <span className="text-sm text-gray-600 [&_.logo-link]:text-2xl [&_.logo-link>svg]:!align-middle [&_.logo-link>img]:!align-middle">{secondLine}</span>}
-                {linkHref && <a href={linkHref} target="_blank" className="text-sm text-nowrap hover:border-b border-b-gray-800">{linkText}
-                    <svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M2.31787 9.18188L7.97472 3.52503" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
-                        <path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
-                    </svg>
-                </a>}
+                {linkHref && <a href={linkHref} target="_blank" className="text-sm text-nowrap hover:border-b border-b-gray-800">{linkText}</a>}
             </cite>
         </article>
     );

--- a/src/components/TestimonialsSlider.tsx
+++ b/src/components/TestimonialsSlider.tsx
@@ -50,12 +50,7 @@ export default function TestimonialsSlider() {
                                     <cite className="not-italic self-start">
                                         <p className="font-bold text-xl">{name}</p>
                                         {secondLine && <span className="not-italic [&_.logo-link]:text-xl">{secondLine}</span>}
-                                        {linkHref && <a href={linkHref} target="_blank" className="text-nowrap hover:border-b border-b-gray-800">{linkText}
-                                            <svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M2.31787 9.18188L7.97472 3.52503" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
-                                                <path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="black" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
-                                            </svg>
-                                        </a>}
+                                        {linkHref && <a href={linkHref} target="_blank" className="text-nowrap hover:border-b border-b-gray-800">{linkText}</a>}
                                     </cite>
                                 </article>
                             ))}

--- a/src/data/testimonials.tsx
+++ b/src/data/testimonials.tsx
@@ -31,7 +31,7 @@ export const testimonials: Testimonial[] = [
         quote: "Jared has been a great resource for our firm. He promptly executes on updates to our site and is a pleasure to work with.",
         shorterQuote: "Jared has been a great resource … promptly executes on updates … is a pleasure to work with.",
         name: "Susie Baker",
-        secondLine: <>Chief Operating Officer at <a href="https://spearstreetcapital.com/" target="_blank" className="logo-link"><L name="spearstreet" /><svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.31787 9.18188L7.97472 3.52503" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /><path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /></svg></a></>,
+        secondLine: <>Chief Operating Officer at <a href="https://spearstreetcapital.com/" target="_blank" className="logo-link"><L name="spearstreet" /></a></>,
     },
     {
         id: 4234,
@@ -45,7 +45,7 @@ export const testimonials: Testimonial[] = [
         quote: "Jared was an outstanding software engineer on our team—technically sharp, collaborative, and always focused on delivering high-quality solutions. He consistently took initiative to solve complex problems and improve our product experience, often going above and beyond expectations. Any team would be lucky to have Jared's combination of technical excellence and strong communication skills.",
         shorterQuote: "Jared was an outstanding software engineer on our team—technically sharp, collaborative, and always focused on delivering high-quality solutions. He consistently took initiative … technical excellence and strong communication skills.",
         name: "David Skara",
-        secondLine: <>Product Manager at <a href="https://www.elephant.is/" target="_blank" className="logo-link"><L name="elephant" /><svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.31787 9.18188L7.97472 3.52503" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /><path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" /></svg></a></>,
+        secondLine: <>Product Manager at <a href="https://www.elephant.is/" target="_blank" className="logo-link"><L name="elephant" /></a></>,
     },
     {
         id: 1,


### PR DESCRIPTION
## Summary
Removes unused SVG arrow icons from external links in testimonial citations (Spear Street Capital and Elephant). Also cleans up unused arrow code from the citation link components.

## Changes
- Removed arrow SVGs from Susie Baker (Spear Street) and David Skara (Elephant) testimonial citations in data
- Cleaned up unused arrow SVG markup from linkHref rendering in both grid and slider components