### PR TITLE
Add breathing room under CTA and footer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,11 +136,16 @@ export default async function Home() {
           heading="Let's work together"
           description={
             <>
-              I&apos;m actively looking for a full-time role at a thoughtful,
-              purpose-driven startup—NYC or remote—as a senior front-end or
-              full-stack developer. I&apos;m also currently taking on select
-              freelance projects, always excited to work with new people on
-              fresh challenges.
+              I&apos;m{" "}
+              <b className="font-[500]">
+                actively looking for a full-time role
+              </b>{" "}
+              at a thoughtful, purpose-driven startup—NYC or remote—as a senior
+              front-end or full-stack developer. I&apos;m also{" "}
+              <b className="font-[500]">
+                currently taking on select freelance projects
+              </b>
+              , always excited to work with new people on fresh challenges.
             </>
           }
         />

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -22,7 +22,7 @@ export default function CTASection({ heading, description, divider = true, card 
     }
 
     return (
-        <section className="py-12">
+        <section className="pt-12 pb-24">
             <div className="page-container">
                 <div className="prose prose-xl mb-6">
                     <h2>{heading}</h2>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="footer text-gray-800 pb-16 relative">
+    <footer className="footer text-gray-800 pt-8 pb-28 relative">
     <div className="page-container">
       <ul className="p-0">
         <li className="mx-2 inline-block">


### PR DESCRIPTION
Increases vertical spacing on both pages for better visual breathing room.

- CTA section: doubled bottom padding to 96px
- Footer: added top padding and increased bottom to 112px
- Homepage CTA: emphasized key phrases with font-[500] styling to match resume page

Both pages now have consistent styling and improved layout spacing.