### PR TITLE
Fix Nike logo clipping on bottom

### DIFF
--- a/src/components/InlineLogo.tsx
+++ b/src/components/InlineLogo.tsx
@@ -205,7 +205,7 @@ const logos: Record<string, ReactNode> = {
     </svg>
   ),
   nike: (
-    <svg viewBox="0 7.5 24 8.5" className="inline-block h-[1em] w-auto my-[-0.1em] align-[-0.1em]">
+    <svg viewBox="0 6.5 24 11" className="inline-block h-[1em] w-auto my-[-0.1em] align-[-0.1em]">
       <path
         fill="currentColor"
         d="M24 7.8L6.442 15.276c-1.456.616-2.679.925-3.668.925-1.12 0-1.933-.392-2.437-1.177-.317-.504-.41-1.143-.28-1.918.13-.775.476-1.6 1.036-2.478.467-.71 1.232-1.643 2.297-2.8a6.122 6.122 0 00-.784 1.848c-.28 1.195-.028 2.072.756 2.632.373.261.886.392 1.54.392.522 0 1.11-.084 1.764-.252L24 7.8z"


### PR DESCRIPTION
The Nike logo in the resume's Hugo & Marie section was clipping at the bottom edge due to a tight viewBox. 

Adjusted the SVG viewBox from `0 7.5 24 8.5` to `0 6.5 24 11` to provide proper spacing around the swoosh and prevent clipping.