### PR TITLE
Style stats as scannable byline

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "npm install",
-    "run": "npm run dev",
+    "run": "rm -f .next/dev/lock && npm run dev",
     "archive": ""
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,13 +48,13 @@ export default async function Home() {
                 <span className="logo-group"><span className="logo-link"><L name="openai" /></span>{" "}OpenAI</span>,
                 {" "}and{" "}<span className="logo-group"><span className="logo-link"><L name="comcast" /></span>{" "}Comcast</span>.
               </h1>
-              <dl className="not-prose grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5 text-[18px] mt-6 mb-8 font-black">
-                <dt>Experience:</dt>
-                <dd>8+ years</dd>
-                <dt>Focus:</dt>
-                <dd>Front-end-leaning full-stack development</dd>
-                <dt>Location:</dt>
-                <dd>New York City, NY</dd>
+              <dl className="not-prose grid grid-cols-[auto_1fr] gap-x-6 gap-y-0.5 text-[14px] mt-5 mb-8">
+                <dt className="text-gray-500">Experience</dt>
+                <dd className="font-semibold">8+ years</dd>
+                <dt className="text-gray-500">Focus</dt>
+                <dd className="font-semibold">Front-end-leaning full-stack development</dd>
+                <dt className="text-gray-500">Location</dt>
+                <dd className="font-semibold">New York City, NY</dd>
               </dl>
               <p>
                 I take ownership of projects from planning to deployment,


### PR DESCRIPTION
Restyle the Experience, Focus, and Location stats section under the homepage headline to feel like a scannable byline rather than prominent call-outs.

**Changes:**
- Reduced font size from 18px to 14px
- Made labels lighter gray (text-gray-500)
- Made values semibold for hierarchy
- Removed colons from labels
- Tightened vertical spacing

Also added cleanup of stale .next/dev/lock file to the dev server startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)