### PR TITLE
Update resume headline to 'My work background'

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "npm install",
-    "run": "npm run dev",
+    "run": "rm -f .next/dev/lock && npm run dev",
     "archive": ""
   }
 }

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -56,11 +56,14 @@ export default async function BackgroundPage() {
                 )}
 
                 <section className="page-container py-16">
-                    <div className="mb-10">
+                    <div className="mb-10 flex items-center gap-4">
+                        <div className="prose prose-lg max-w-none">
+                            <h1 className="m-0">My work background</h1>
+                        </div>
                         <a
                             target="_blank"
                             href="/resume.pdf"
-                            className="font-sans text-xs uppercase tracking-widest hover:underline inline-flex items-center gap-1 mb-2"
+                            className="font-sans text-xs uppercase tracking-widest hover:underline inline-flex items-center gap-1 shrink-0"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
@@ -69,9 +72,6 @@ export default async function BackgroundPage() {
                             </svg>
                             view as pdf
                         </a>
-                        <div className="prose prose-lg max-w-none">
-                            <h1 className="m-0">Resume</h1>
-                        </div>
                     </div>
                     <ResumeContent resume={resume} />
                 </section>


### PR DESCRIPTION
Change the resume page headline from "Resume" to "My work background" and position the "view as pdf" button next to it with center alignment, since the navigation already labels this section as "Resume".

Also add lock file cleanup to the dev script per project best practices.