### PR TITLE
Use chunky sans font weight for resume company names and descriptions

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "npm install",
-    "run": "npm run dev",
+    "run": "rm -f .next/dev/lock && npm run dev",
     "archive": ""
   }
 }

--- a/src/components/ResumeContent.tsx
+++ b/src/components/ResumeContent.tsx
@@ -101,7 +101,7 @@ export default function ResumeContent({ resume }: Props) {
       {resume.experience.map((job) => (
         <div key={job.company} className="mt-8 first:mt-0">
           <div className="flex justify-between items-baseline gap-4 mb-1">
-            <h3 className="m-0 font-bold leading-tight">{(() => {
+            <h3 className="m-0 font-black leading-tight">{(() => {
               if (job.company.startsWith('Huge')) {
                 return <><L name="huge" /> <L name="elephant" />{' '}{job.company}</>
               }
@@ -110,7 +110,7 @@ export default function ResumeContent({ resume }: Props) {
             })()}</h3>
             <span className="text-sm font-bold tabular-nums shrink-0">{job.period}</span>
           </div>
-          <p className="text-[14px] italic leading-snug mt-0.5 mb-1">{logoifyText(job.description, 0)}</p>
+          <p className="text-[14px] italic leading-snug mt-0.5 mb-1 font-black">{logoifyText(job.description, 0)}</p>
 
           {job.clients && (
             <ul className="list-disc ml-5 text-[15px] leading-snug space-y-0">


### PR DESCRIPTION
Apply font-black (900 weight) to resume experience headings and descriptions to match the chunky Helvetica Neue style used in the homepage intro paragraph. Also updates the dev script to remove stale lock files on startup.