### PR TITLE
Update tile hover state to solid black overlay

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "npm install",
-    "run": "npm run dev",
+    "run": "rm -f .next/dev/lock && npm run dev",
     "archive": ""
   }
 }

--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -13,23 +13,11 @@ export default function ArticlePreview({
 }) {
   const overlay = (
     <>
-      {/* Desktop hover overlay */}
-      <div
-        className="article-preview-blur absolute inset-0 z-20 backdrop-blur-0 transition-[backdrop-filter] duration-300 group-hover:backdrop-blur-[6px] pointer-events-none"
-        style={{
-          mask: "linear-gradient(to top, white 0%, white 30%, transparent 90%)",
-        }}
-      />
+      {/* Desktop hover overlay: solid black with white text */}
+      <div className="article-preview-overlay absolute inset-0 z-20 bg-black/90 opacity-0 transition-opacity duration-300 group-hover:opacity-100 pointer-events-none" />
       <div className="article-preview-overlay absolute inset-0 z-20 opacity-0 transition-opacity duration-300 group-hover:opacity-100 pointer-events-none">
-        <div
-          className="absolute inset-0"
-          style={{
-            background: "linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.3) 40%, transparent 70%)",
-          }}
-        />
-        {/* Content */}
-        <div className="absolute inset-0 flex flex-col justify-end p-5" style={{ textShadow: "0 1px 2px rgba(0,0,0,0.2)" }}>
-          <h3 className="text-white font-semibold text-lg mb-1" style={{ textShadow: "0 1px 3px rgba(0,0,0,0.3)" }}>
+        <div className="absolute inset-0 flex flex-col justify-end p-5">
+          <h3 className="text-white font-semibold text-lg leading-snug mb-1">
             {frontMatter.title}
           </h3>
           {frontMatter.excerpt && (
@@ -38,7 +26,7 @@ export default function ArticlePreview({
             </p>
           )}
           {hasContent && (
-            <p className="text-white/85 text-sm mt-2 mb-0">
+            <p className="text-white/85 text-sm font-medium mt-2 mb-0 hover:underline pointer-events-auto">
               Read more <svg className="inline w-3 h-3 ml-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
             </p>
           )}

--- a/src/components/ProjectsCarousel.tsx
+++ b/src/components/ProjectsCarousel.tsx
@@ -64,7 +64,15 @@ export default function ProjectsCarousel({
     const el = scrollRef.current;
     const close = () => setExpandedIndex(null);
     el?.addEventListener("scroll", close, { passive: true });
-    return () => el?.removeEventListener("scroll", close);
+    const handleTapOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest(".carousel-item")) close();
+    };
+    document.addEventListener("pointerdown", handleTapOutside);
+    return () => {
+      el?.removeEventListener("scroll", close);
+      document.removeEventListener("pointerdown", handleTapOutside);
+    };
   }, [expandedIndex]);
 
   const scroll = useCallback((direction: 1 | -1) => {
@@ -133,61 +141,47 @@ export default function ProjectsCarousel({
                   shadow
                   material3d
                 >
-                  {/* Always-visible title (touch) / hover overlay (desktop) */}
+                  {/* Solid black overlay (desktop hover) / touch expanded */}
+                  <div className="carousel-overlay-bg absolute inset-0 z-20 bg-black/90 pointer-events-none transition-opacity duration-300" />
+                  {/* Bottom gradient for touch title readability */}
                   <div
-                    className="carousel-overlay-blur absolute inset-0 z-20 pointer-events-none transition-[backdrop-filter] duration-300"
-                    style={{
-                      mask: "linear-gradient(to top, white 0%, white 30%, transparent 90%)",
-                    }}
+                    className="carousel-overlay-gradient absolute inset-0 z-20 pointer-events-none transition-opacity duration-300"
+                    style={{ background: "linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.3) 40%, transparent 70%)" }}
                   />
-                  {/* Gradient + text overlay */}
+                  {/* Text overlay */}
                   <div
                     className="carousel-overlay-info absolute inset-0 z-30 pointer-events-none transition-opacity duration-300"
-                    style={{ transform: "translateZ(0)" }}
                   >
-                    <div
-                      className="absolute inset-0"
-                      style={{
-                        background:
-                          "linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.3) 40%, transparent 70%)",
-                      }}
-                    />
-                    <div
-                      className="absolute inset-0 flex flex-col justify-end p-5"
-                      style={{ textShadow: "0 1px 2px rgba(0,0,0,0.2)" }}
-                    >
-                      <h2
-                        className="text-white font-semibold text-lg mb-1"
-                        style={{
-                          textShadow: "0 1px 3px rgba(0,0,0,0.3)",
-                        }}
-                      >
+                    <div className="absolute inset-0 flex flex-col justify-end px-3 pt-3 pb-4 sm:p-5">
+                      <h2 className="text-white font-semibold text-lg leading-snug">
                         {frontMatter.title}
                       </h2>
                       {/* Excerpt + Read more: visible on hover (desktop) or when expanded (touch) */}
                       <div className="carousel-overlay-details">
-                        {frontMatter.excerpt && (
-                          <p className="text-white/85 text-sm line-clamp-3 leading-snug">
-                            {frontMatter.excerpt}
-                          </p>
-                        )}
-                        {hasContent && (
-                          <p className="text-white/85 text-sm mt-2 mb-0">
-                            Read more{" "}
-                            <svg
-                              className="inline w-3 h-3 ml-0.5"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2.5"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            >
-                              <path d="M5 12h14" />
-                              <path d="m12 5 7 7-7 7" />
-                            </svg>
-                          </p>
-                        )}
+                        <div>
+                          {frontMatter.excerpt && (
+                            <p className="text-white/85 text-sm line-clamp-3 leading-snug pt-1">
+                              {frontMatter.excerpt}
+                            </p>
+                          )}
+                          {hasContent && (
+                            <p className="text-white/85 text-sm font-medium mt-2 mb-0 hover:underline pointer-events-auto">
+                              Read more{" "}
+                              <svg
+                                className="inline w-3 h-3 ml-0.5"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              >
+                                <path d="M5 12h14" />
+                                <path d="m12 5 7 7-7 7" />
+                              </svg>
+                            </p>
+                          )}
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -51,6 +51,10 @@
   color: inherit;
 }
 
+a.carousel-item {
+  cursor: pointer;
+}
+
 .carousel-item-image {
   position: relative;
   aspect-ratio: 1.6 / 1;
@@ -77,18 +81,12 @@
 
 /* Desktop: overlay hidden until hover */
 @media (hover: hover) {
-  .carousel-overlay-blur {
-    backdrop-filter: blur(0.5px);
-  }
-
+  .carousel-overlay-bg,
   .carousel-overlay-info {
     opacity: 0;
   }
 
-  .carousel-item:hover .carousel-overlay-blur {
-    backdrop-filter: blur(6px);
-  }
-
+  .carousel-item:hover .carousel-overlay-bg,
   .carousel-item:hover .carousel-overlay-info {
     opacity: 1;
   }
@@ -96,8 +94,13 @@
 
 /* Touch: gradient+title always visible, details hidden until expanded */
 @media (hover: none) {
-  .carousel-overlay-blur {
-    backdrop-filter: blur(0px);
+  .carousel-overlay-bg {
+    opacity: 0;
+    transition: opacity 300ms ease;
+  }
+
+  .carousel-overlay-gradient {
+    opacity: 1;
   }
 
   .carousel-overlay-info {
@@ -112,17 +115,29 @@
     overflow: hidden;
   }
 
-  .carousel-overlay-details > * {
+  .carousel-overlay-details > div {
     min-height: 0;
+    overflow: hidden;
   }
 
-  .carousel-item-expanded .carousel-overlay-blur {
-    backdrop-filter: blur(6px);
+  .carousel-item-expanded .carousel-overlay-bg {
+    opacity: 1;
+  }
+
+  .carousel-item-expanded .carousel-overlay-gradient {
+    opacity: 0;
   }
 
   .carousel-item-expanded .carousel-overlay-details {
     grid-template-rows: 1fr;
     opacity: 1;
+  }
+}
+
+/* Gradient only for touch - hidden on desktop */
+@media (hover: hover) {
+  .carousel-overlay-gradient {
+    display: none;
   }
 }
 
@@ -161,6 +176,12 @@
       opacity: 1;
       pointer-events: auto;
     }
+  }
+}
+
+@media (hover: none) {
+  .carousel-edge {
+    display: none;
   }
 }
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,7 +1,6 @@
 /* Article preview tiles: text below in 1-col, hover overlay in 2-col (lg+) */
 .article-preview {
-  .article-preview-overlay,
-  .article-preview-blur {
+  .article-preview-overlay {
     display: none;
   }
 
@@ -16,8 +15,7 @@
   }
 
   @media (width >= 1024px) and (hover: hover) {
-    .article-preview-overlay,
-    .article-preview-blur {
+    .article-preview-overlay {
       display: flex;
     }
 
@@ -36,14 +34,15 @@
         position: absolute;
         inset: 0;
         z-index: 10;
-        transition: opacity ease-in-out 50ms;
-        background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 70%, rgba(0, 0, 0, .3) 100%);
+        transition: opacity ease-in-out 150ms;
+        background: rgba(0, 0, 0, 0.9);
+        opacity: 0;
       }
     }
   }
 
   h2 {
-    transition: opacity ease-in-out 50ms;
+    transition: opacity ease-in-out 150ms;
     text-shadow: 0px 1px 3px rgba(0, 0, 0, .3);
   }
 


### PR DESCRIPTION
## Summary
- Changed carousel and article tile hover effects from blur + gradient to semi-transparent black (90% opacity) background
- Desktop hovers reveal full black overlay with white text; touch devices show gradient for readability, expanding to black on tap
- Fixed grid collapse on touch to prevent title misalignment on clickable tiles
- Added arrow hiding on touch devices and improved text spacing around rounded corners

## Test plan
- [ ] Test hover on desktop: tiles fade to black overlay with white text
- [ ] Test on mobile: gradient shows title, tapping expands to black with excerpt visible
- [ ] Test clicking outside expanded tile closes it
- [ ] Verify "Read more" text is bold and underlines on hover
- [ ] Check all three lines of excerpt text are visible without clipping