### PR TITLE
Add John Simon testimonial and rebalance testimonials grid

### DIFF
--- a/src/components/TestimonialsGrid.tsx
+++ b/src/components/TestimonialsGrid.tsx
@@ -1,6 +1,6 @@
 import { type Testimonial, testimonials } from "@/data/testimonials";
 
-const gridOrder = [1234423, 2, 23, 4234, 54325, 1, 3];
+const gridOrder = [7, 1234423, 23, 2, 1, 3, 4234, 54325];
 const testimonialsById = new Map(testimonials.map((testimonial) => [testimonial.id, testimonial]));
 const orderedTestimonials = gridOrder
     .map((id) => testimonialsById.get(id))
@@ -14,8 +14,13 @@ function TestimonialCard({ linkHref, linkText, name, shorterQuote, secondLine }:
             </blockquote>
             <cite className="not-italic">
                 <p className="font-bold text-base">{name}</p>
-                {secondLine && <span className="text-sm text-gray-600 [&_.logo-link]:text-2xl [&_.logo-link>svg]:!align-middle [&_.logo-link>img]:!align-middle">{secondLine}</span>}
-                {linkHref && <a href={linkHref} target="_blank" className="text-sm text-nowrap hover:border-b border-b-gray-800">{linkText}</a>}
+                {secondLine && <span className="block text-sm text-gray-600 [&_.logo-link]:text-2xl [&_.logo-link>svg]:!align-middle [&_.logo-link>img]:!align-middle">{secondLine}</span>}
+                {linkHref && <a href={linkHref} target="_blank" className="block text-sm text-nowrap hover:border-b border-b-gray-800 w-fit">{linkText}
+                    <svg className="inline ml-1" style={{ marginTop: -1 }} width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M2.31787 9.18188L7.97472 3.52503" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
+                        <path d="M3.73242 2.81812L8.68217 2.81812L8.68217 7.76786" stroke="currentColor" strokeWidth="1.75" strokeLinecap="square" strokeLinejoin="round" />
+                    </svg>
+                </a>}
             </cite>
         </article>
     );

--- a/src/components/TestimonialsSlider.tsx
+++ b/src/components/TestimonialsSlider.tsx
@@ -11,7 +11,7 @@ import 'swiper/css/autoplay';
 import "@/styles/testimonials.css";
 import { type Testimonial, testimonials } from "@/data/testimonials";
 
-const sliderOrder = [1234423, 4234, 1, 54325, 2, 3, 23];
+const sliderOrder = [1234423, 4234, 1, 54325, 2, 3, 23, 7];
 const compactQuoteIds = new Set([1234423, 4234, 1, 54325]);
 const testimonialsById = new Map(testimonials.map((testimonial) => [testimonial.id, testimonial]));
 const orderedTestimonials = sliderOrder

--- a/src/data/testimonials.tsx
+++ b/src/data/testimonials.tsx
@@ -50,7 +50,7 @@ export const testimonials: Testimonial[] = [
     {
         id: 1,
         quote: <>Jared was a smart choice to develop my personal portfolio. He accomplished all the things I was worried wouldn&apos;t work and was very patient with all my questions and feedback! He was very responsive and quick with updates. He even met with me in person to show me how to use the custom template he built in <span className="logo-group"><span className="logo-link"><L name="wordpress" /></span>{" "}WordPress</span>. The project met my vision and I am very happy with it. Thank you!</>,
-        shorterQuote: <>He accomplished all the things I was worried wouldn&apos;t work and was very patient with all my questions and feedback! He was very responsive and quick with updates. He even met with me in person to show me how to use the custom template he built in <span className="logo-group"><span className="logo-link"><L name="wordpress" /></span>{" "}WordPress</span>. The project met my vision and I am very happy with it.</>,
+        shorterQuote: <>He accomplished all the things I was worried wouldn&apos;t work … very responsive … He even met with me in person to show me how to use the custom template he built in <span className="logo-group"><span className="logo-link"><L name="wordpress" /></span>{" "}WordPress</span>. The project met my vision and I am very happy with it.</>,
         name: "Denise M.",
         secondLine: "Graphic design portfolio client",
     },
@@ -60,5 +60,14 @@ export const testimonials: Testimonial[] = [
         shorterQuote: "Jared was easy to get a hold of and plan out the project with. He was flexible as we had to change things around mid-project and stuck to timelines and budget.",
         name: "Zach Holub",
         secondLine: "Physical therapy website client",
+    },
+    {
+        id: 7,
+        quote: "Jared Salzano came to my rescue a few times when I had website problems and he was always knowledgable, quick and efficient. When I felt that my website was long overdue for an overhaul, I found Jared to be a brilliant collaborator both in his technical skills and in his creative ideas. He was patient and courteous when it came to my lack of understanding. I would recommend Jared most heartily to anyone like me who wants a bright, cooperative and kind partner. I’m most grateful for the experience and the result of our work together.",
+        shorterQuote: "I found Jared to be a brilliant collaborator … patient and courteous … a bright, cooperative and kind partner.",
+        name: "John Simon",
+        secondLine: "Record producer and songwriter",
+        linkHref: "https://johnsimonmusic.net/",
+        linkText: "johnsimonmusic.net",
     }
 ];


### PR DESCRIPTION
## Summary
- Adds a testimonial from record producer and songwriter John Simon, linked to johnsimonmusic.net with an external-link arrow
- Reorders `gridOrder` so John, Avi, and Adam anchor the top row of the 3-column grid, with columns balanced at ~980/1090/990px
- Trims Denise's `shorterQuote` for a tighter card and puts each cite-block line (`secondLine`, link) on its own row

## Test plan
- [ ] Visit the homepage Testimonials section at lg/sm/mobile widths and confirm columns look balanced and John's card is top-left
- [ ] Confirm `johnsimonmusic.net ↗` opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)